### PR TITLE
use go timer exclusively if kernel version is older than 5.19.0, sinc…

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func init() {
 	flag.StringVar(&memProfile, "memprofile", "", "write memory profile to `file`")
 	osInfo, _ := helpers.GetOSInfo()
 	if age, _ := osInfo.CompareOSBaseKernelRelease("5.19.0"); helpers.KernelVersionNewer == age {
+		log.Printf("warning: perf timer not supported, use kernel version older than 5.19.0. falling back to go timer.\n")
 		goTimerOnly = true
 	}
 }

--- a/network-microburst.bpf.c
+++ b/network-microburst.bpf.c
@@ -181,8 +181,10 @@ int calc_metrics(struct bpf_perf_event_data *ctx)
 }
 
 static __u64 get_rx_metrics() {
+
     __u64 bytes = 0;
     int i = 0;
+    
     if (LINUX_VERSION_CODE > KERNEL_VERSION(5,19,0)) {
         bpf_printk("Kernel version doesnt support perf timer.");
         bpf_map_lookup_percpu_elem = &__bpf_map_lookup_percpu_elem;

--- a/network-microburst.bpf.c
+++ b/network-microburst.bpf.c
@@ -186,7 +186,7 @@ static __u64 get_rx_metrics() {
     int i = 0;
     
     if (LINUX_VERSION_CODE > KERNEL_VERSION(5,19,0)) {
-        bpf_printk("Kernel version doesnt support perf timer.");
+        // unsupported fn in older kernels
         bpf_map_lookup_percpu_elem = &__bpf_map_lookup_percpu_elem;
         return bytes;
     }   
@@ -210,7 +210,7 @@ static __u64 get_tx_metrics() {
     __u64 bytes = 0;
 
     if (LINUX_VERSION_CODE > KERNEL_VERSION(5,19,0)) {
-        bpf_printk("Kernel version doesnt support perf timer.");
+        // unsupported fn in older kernels
         bpf_map_lookup_percpu_elem = &__bpf_map_lookup_percpu_elem;
         return bytes;
     }

--- a/network-microburst.bpf.c
+++ b/network-microburst.bpf.c
@@ -186,7 +186,7 @@ static __u64 get_rx_metrics() {
     int i = 0;
     
     if (LINUX_VERSION_CODE > KERNEL_VERSION(5,19,0)) {
-        // unsupported fn in older kernels
+        // unsupported fn in kernels older than 5.19
         bpf_map_lookup_percpu_elem = &__bpf_map_lookup_percpu_elem;
         return bytes;
     }   
@@ -210,7 +210,7 @@ static __u64 get_tx_metrics() {
     __u64 bytes = 0;
 
     if (LINUX_VERSION_CODE > KERNEL_VERSION(5,19,0)) {
-        // unsupported fn in older kernels
+        // unsupported fn in kernels older than 5.19
         bpf_map_lookup_percpu_elem = &__bpf_map_lookup_percpu_elem;
         return bytes;
     }

--- a/network-microburst.bpf.c
+++ b/network-microburst.bpf.c
@@ -12,8 +12,8 @@
 
 static void *(*bpf_map_lookup_percpu_elem)(void *map, const void *key, u32 cpu);
 
+// A dummy stand-in replacement function for older kernels
 void* __bpf_map_lookup_percpu_elem(void *map, const void *key, u32 cpu) {
-    // Do Nothing
     return NULL;
 }
 


### PR DESCRIPTION
…e bpf_map_lookup_percpu_elem was introduced later